### PR TITLE
feature/Newsletter-Subscription

### DIFF
--- a/cartridges/app_training/cartridge/controllers/NewsletterSubscription.js
+++ b/cartridges/app_training/cartridge/controllers/NewsletterSubscription.js
@@ -7,103 +7,88 @@ var CustomObjectMgr = require('dw/object/CustomObjectMgr');
 var Transaction = require('dw/system/Transaction');
 var CouponMgr = require('dw/campaign/CouponMgr');
 var newsletterEmailHelpers = require('*/cartridge/scripts/helpers/newsletterEmailHelpers');
-var Site = require('dw/system/Site');
+
 
 /**
-* Renders the newsletter subscription form page with a URL for subscribing.
-* 
-* This function handles the 'Form' route for the newsletter subscription, ensuring
-* that the request is made over HTTPS. It constructs a URL for the subscription
-* action and renders the 'newsletterSubscription' template with initial form values.
-* 
-* @param {Object} req - The server request object, containing query parameters and other request data.
-* @param {Object} res - The server response object, used to render the template and send the response.
-* @param {Function} next - The next middleware function in the stack, called to pass control to the next handler.
-* 
-* @property {string} req.querystring.rurl - The return URL parameter from the query string, defaulting to '1' if not provided.
-* 
-* @returns {void} - This function does not return a value. It renders a template and calls the next middleware.
+* Handles the 'Show' route for displaying the newsletter subscription page.
+*
+* This function retrieves the target URL from the query string, constructs the
+* subscription URL, and prepares the newsletter subscription form for rendering.
+* It then renders the 'newsletterSubscription' template with the necessary data.
+*
+* @param {Object} req - The server request object containing the query string parameters.
+* @param {Object} res - The server response object used to render the page.
+* @param {Function} next - The callback function to pass control to the next middleware.
 */
-server.get('Show', server.middleware.https, function (req, res, next) {
+server.get('Show', function (req, res, next) {
     var target = req.querystring.rurl || 1;
     var subscribeNewsletterUrl = URLUtils.url('NewsletterSubscription-Subscribe', 'rurl', target).relative().toString();
-
+    
+    var profileForm = server.forms.getForm('newsletterSubscription');
+    profileForm.clear();
+    
     res.render('newsletterSubscription', {
         subscribeNewsletterUrl: subscribeNewsletterUrl,
-        email: '',
-        firstName: '',
-        lastName: ''
+        profileForm: profileForm
     });
     next();
 });
 
 
 /**
-* Handles the subscription to a newsletter by processing the user's email and name, 
-* checking for existing subscriptions, and assigning a coupon code if available.
+* Handles the subscription process for the newsletter by creating a custom object for the subscriber
+* and optionally assigning a coupon code. If the email is already subscribed, an error message is displayed.
 * 
 * @function
-* @param {Object} req - The server request object containing form data.
+* @param {Object} req - The server request object containing form data for subscription.
 * @param {Object} res - The server response object used to render views or redirect.
-* @param {Function} next - The next middleware function in the stack.
-* 
-* @returns {void}
+* @param {Function} next - The callback function to pass control to the next middleware.
 * 
 * @throws Will render an error message if there is an issue with the subscription process.
 * 
-* @description This function is triggered by a POST request to the 'Subscribe' endpoint. 
-* It retrieves the user's email, first name, and last name from the request form. 
-* It checks if the email is already subscribed by querying the 'NewsletterSubscription' custom object. 
-* If the email is already subscribed, it renders an error message. 
-* If not, it attempts to retrieve a coupon code from the 'NewsletterSubscription' coupon manager. 
-* If a coupon code is available, it creates a new custom object for the subscription, 
-* assigns the email and coupon code to it, and sends a notification email with the coupon code. 
-* If no coupon code is available, it sends a notification email without a coupon code. 
-* In both cases, it redirects the user to the home page. 
-* If an error occurs during the process, it catches the exception and renders an error message.
+* @description This function processes a POST request to subscribe a user to the newsletter. It checks if the 
+* email is already subscribed, and if not, creates a new subscription entry in the custom object manager. 
+* A coupon code is generated and assigned if available. A notification email is sent to the subscriber. 
+* The user is redirected to the home page upon successful subscription.
 */
-server.post('Subscribe', server.middleware.https, function (req, res, next) {
-    var email = req.form.subscribeEmail;
+server.post('Subscribe', function (req, res, next) {
+    var email = req.form.subscribeFormEmail;
     var firstName = req.form.subscribeFormFirstname;
-    var lastName = req.form.subscribeLastname;
+    var lastName = req.form.subscribeFormLastname;
 
     try {
+        var existingSubscription = CustomObjectMgr.getCustomObject('NewsletterSubscription', email);
+        if (existingSubscription) {
+            res.render('newsletterSubscription', {
+                error: Resource.msg('error.message.already.subscribed', 'newsletter', null)
+            });
+            return next();
+        }
+        
+        var couponCode;
         Transaction.wrap(function () {
-            var existingSubscription = CustomObjectMgr.getCustomObject('NewsletterSubscription', email);
-            if (existingSubscription) {
-                res.render('newsletterSubscription', {
-                    error: Resource.msg('error.message.already.subscribed', 'newsletter', null)
-                });
-                return next();
-            }
-
             var coupon = CouponMgr.getCoupon('NewsletterSubscription');
-            var couponCode = coupon.getNextCouponCode();
-
-            if (!couponCode) {
-
-                newsletterEmailHelpers.sendNewsletterEmailNotification(email, firstName, lastName);
-                res.redirect(URLUtils.url('Home-Show').toString());
-
-                return next();
-            };
+            if (coupon) {
+                couponCode = coupon.getNextCouponCode();
+            }
 
             var customObject = CustomObjectMgr.createCustomObject('NewsletterSubscription', email);
             customObject.custom.email = email;
-            customObject.custom.couponCode = couponCode;
-
-            newsletterEmailHelpers.sendNewsletterEmailNotification(email, firstName, lastName, couponCode);
-            res.redirect(URLUtils.url('Home-Show').toString());
+            if (couponCode) {
+                customObject.custom.couponCode = couponCode;
+            }
         });
+
+        newsletterEmailHelpers.sendNewsletterEmailNotification(email, firstName, lastName, couponCode);
+        res.redirect(URLUtils.url('Home-Show').toString());
 
     } catch (e) {
         res.render('newsletterSubscription', {
             error: Resource.msg('subscribe.email.error', 'newsletter', null)
         });
-        return next();
     }
 
-    next();
+    return next();
 });
 
 module.exports = server.exports();

--- a/cartridges/app_training/cartridge/controllers/NewsletterSubscription.js
+++ b/cartridges/app_training/cartridge/controllers/NewsletterSubscription.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var server = require('server');
+var URLUtils = require('dw/web/URLUtils');
+var Resource = require('dw/web/Resource');
+var CustomObjectMgr = require('dw/object/CustomObjectMgr');
+var Transaction = require('dw/system/Transaction');
+var CouponMgr = require('dw/campaign/CouponMgr');
+var newsletterEmailHelpers = require('*/cartridge/scripts/helpers/newsletterEmailHelpers');
+var Site = require('dw/system/Site');
+
+/**
+* Renders the newsletter subscription form page with a URL for subscribing.
+* 
+* This function handles the 'Form' route for the newsletter subscription, ensuring
+* that the request is made over HTTPS. It constructs a URL for the subscription
+* action and renders the 'newsletterSubscription' template with initial form values.
+* 
+* @param {Object} req - The server request object, containing query parameters and other request data.
+* @param {Object} res - The server response object, used to render the template and send the response.
+* @param {Function} next - The next middleware function in the stack, called to pass control to the next handler.
+* 
+* @property {string} req.querystring.rurl - The return URL parameter from the query string, defaulting to '1' if not provided.
+* 
+* @returns {void} - This function does not return a value. It renders a template and calls the next middleware.
+*/
+server.get('Show', server.middleware.https, function (req, res, next) {
+    var target = req.querystring.rurl || 1;
+    var subscribeNewsletterUrl = URLUtils.url('NewsletterSubscription-Subscribe', 'rurl', target).relative().toString();
+
+    res.render('newsletterSubscription', {
+        subscribeNewsletterUrl: subscribeNewsletterUrl,
+        email: '',
+        firstName: '',
+        lastName: ''
+    });
+    next();
+});
+
+
+/**
+* Handles the subscription to a newsletter by processing the user's email and name, 
+* checking for existing subscriptions, and assigning a coupon code if available.
+* 
+* @function
+* @param {Object} req - The server request object containing form data.
+* @param {Object} res - The server response object used to render views or redirect.
+* @param {Function} next - The next middleware function in the stack.
+* 
+* @returns {void}
+* 
+* @throws Will render an error message if there is an issue with the subscription process.
+* 
+* @description This function is triggered by a POST request to the 'Subscribe' endpoint. 
+* It retrieves the user's email, first name, and last name from the request form. 
+* It checks if the email is already subscribed by querying the 'NewsletterSubscription' custom object. 
+* If the email is already subscribed, it renders an error message. 
+* If not, it attempts to retrieve a coupon code from the 'NewsletterSubscription' coupon manager. 
+* If a coupon code is available, it creates a new custom object for the subscription, 
+* assigns the email and coupon code to it, and sends a notification email with the coupon code. 
+* If no coupon code is available, it sends a notification email without a coupon code. 
+* In both cases, it redirects the user to the home page. 
+* If an error occurs during the process, it catches the exception and renders an error message.
+*/
+server.post('Subscribe', server.middleware.https, function (req, res, next) {
+    var email = req.form.subscribeEmail;
+    var firstName = req.form.subscribeFormFirstname;
+    var lastName = req.form.subscribeLastname;
+
+    try {
+        Transaction.wrap(function () {
+            var existingSubscription = CustomObjectMgr.getCustomObject('NewsletterSubscription', email);
+            if (existingSubscription) {
+                res.render('newsletterSubscription', {
+                    error: Resource.msg('error.message.already.subscribed', 'newsletter', null)
+                });
+                return next();
+            }
+
+            var coupon = CouponMgr.getCoupon('NewsletterSubscription');
+            var couponCode = coupon.getNextCouponCode();
+
+            if (!couponCode) {
+
+                newsletterEmailHelpers.sendNewsletterEmailNotification(email, firstName, lastName);
+                res.redirect(URLUtils.url('Home-Show').toString());
+
+                return next();
+            };
+
+            var customObject = CustomObjectMgr.createCustomObject('NewsletterSubscription', email);
+            customObject.custom.email = email;
+            customObject.custom.couponCode = couponCode;
+
+            newsletterEmailHelpers.sendNewsletterEmailNotification(email, firstName, lastName, couponCode);
+            res.redirect(URLUtils.url('Home-Show').toString());
+        });
+
+    } catch (e) {
+        res.render('newsletterSubscription', {
+            error: Resource.msg('subscribe.email.error', 'newsletter', null)
+        });
+        return next();
+    }
+
+    next();
+});
+
+module.exports = server.exports();
+

--- a/cartridges/app_training/cartridge/forms/default/newsletterSubscription.xml
+++ b/cartridges/app_training/cartridge/forms/default/newsletterSubscription.xml
@@ -2,17 +2,15 @@
 <form xmlns="http://www.demandware.com/xml/form/2008-04-19">
     <!-- <group formid="newsletterSubscription"> -->
         <field 
-            formid="subscribeFormFirstname" 
-            label="label.input.firstname" 
-            mandatory="true" 
+            formid="firstname" 
+            mandatory="true"
             max-length="50"
             missing-error="error.message.required" 
             range-error="error.message.50orless" 
             type="string" />
 
         <field 
-            formid="lastName" 
-            label="label.input.lastname" 
+            formid="lastname" 
             mandatory="true" 
             max-length="50" 
             missing-error="error.message.required"
@@ -21,7 +19,6 @@
 
         <field
             formid="email"
-            label="label.input.email" 
             mandatory="true" 
             max-length="50" 
             missing-error="error.message.required"

--- a/cartridges/app_training/cartridge/forms/default/newsletterSubscription.xml
+++ b/cartridges/app_training/cartridge/forms/default/newsletterSubscription.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<form xmlns="http://www.demandware.com/xml/form/2008-04-19">
+    <!-- <group formid="newsletterSubscription"> -->
+        <field 
+            formid="subscribeFormFirstname" 
+            label="label.input.firstname" 
+            mandatory="true" 
+            max-length="50"
+            missing-error="error.message.required" 
+            range-error="error.message.50orless" 
+            type="string" />
+
+        <field 
+            formid="lastName" 
+            label="label.input.lastname" 
+            mandatory="true" 
+            max-length="50" 
+            missing-error="error.message.required"
+            range-error="error.message.50orless" 
+            type="string" />
+
+        <field
+            formid="email"
+            label="label.input.email" 
+            mandatory="true" 
+            max-length="50" 
+            missing-error="error.message.required"
+            parse-error="error.message.parse.email"
+            range-error="error.message.50orless"
+            regexp="^[\w.%+-]+@[\w.-]+\.\w{2,}$" 
+            value-error="error.message.invalid.email"
+            type="string"/> 
+    <!-- </group> -->
+</form>

--- a/cartridges/app_training/cartridge/metadata/Coupons-NewsletterSubscription.xml
+++ b/cartridges/app_training/cartridge/metadata/Coupons-NewsletterSubscription.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coupons xmlns="http://www.demandware.com/xml/impex/coupon/2008-06-17">
+    <coupon coupon-id="NewsletterSubscription">
+        <description>$20 off to each order</description>
+        <enabled-flag>true</enabled-flag>
+        <case-insensitive>true</case-insensitive>
+        <redemption-limits>
+            <limit-per-code>1</limit-per-code>
+            <limit-per-customer>1</limit-per-customer>
+            <limit-per-time-frame>
+                <limit>1</limit>
+                <time-frame>90</time-frame>
+            </limit-per-time-frame>
+            <allow-multiple-codes-per-order>false</allow-multiple-codes-per-order>
+        </redemption-limits>
+        <system-codes>
+            <max-number-of-codes>12</max-number-of-codes>
+            <code-length>16</code-length>
+            <include-vowels>true</include-vowels>
+            <include-dashes>true</include-dashes>
+            <algorithm>F2</algorithm>
+        </system-codes>
+    </coupon>
+
+</coupons>

--- a/cartridges/app_training/cartridge/metadata/Coupons-NewsletterSubscription.xml
+++ b/cartridges/app_training/cartridge/metadata/Coupons-NewsletterSubscription.xml
@@ -14,7 +14,7 @@
             <allow-multiple-codes-per-order>false</allow-multiple-codes-per-order>
         </redemption-limits>
         <system-codes>
-            <max-number-of-codes>12</max-number-of-codes>
+            <max-number-of-codes>33</max-number-of-codes>
             <code-length>16</code-length>
             <include-vowels>true</include-vowels>
             <include-dashes>true</include-dashes>

--- a/cartridges/app_training/cartridge/metadata/CustomObject-NewsletterSubscription.xml
+++ b/cartridges/app_training/cartridge/metadata/CustomObject-NewsletterSubscription.xml
@@ -1,0 +1,28 @@
+<metadata xmlns="http://www.demandware.com/xml/impex/metadata/2006-10-31">
+<custom-type type-id="NewsletterSubscription">
+        <staging-mode>no-staging</staging-mode>
+        <storage-scope>organization</storage-scope>
+        <key-definition attribute-id="email">
+            <type>string</type>
+            <min-length>0</min-length>
+        </key-definition>
+        <attribute-definitions>
+            <attribute-definition attribute-id="couponCode">
+                <display-name xml:lang="x-default">couponCode</display-name>
+                <description xml:lang="x-default">To store the assigned coupon code.</description>
+                <type>string</type>
+                <localizable-flag>false</localizable-flag>
+                <mandatory-flag>true</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+        </attribute-definitions>
+        <group-definitions>
+            <attribute-group group-id="Subscription Details">
+                <display-name xml:lang="x-default">Subscription Details</display-name>
+                <attribute attribute-id="couponCode"/>
+                <attribute attribute-id="email"/>
+            </attribute-group>
+        </group-definitions>
+    </custom-type>
+</metadata>

--- a/cartridges/app_training/cartridge/metadata/SitePreferences-newsletterSenderEmail.xml
+++ b/cartridges/app_training/cartridge/metadata/SitePreferences-newsletterSenderEmail.xml
@@ -1,0 +1,12 @@
+<metadata xmlns="http://www.demandware.com/xml/impex/metadata/2006-10-31">
+<type-extension type-id="SitePreferences">
+    <custom-attribute-definitions>
+        <attribute-definition attribute-id="newsletterSenderEmail">
+            <type>string</type>
+            <mandatory-flag>false</mandatory-flag>
+            <externally-managed-flag>false</externally-managed-flag>
+            <min-length>0</min-length>
+        </attribute-definition>
+    </custom-attribute-definitions>
+</type-extension>
+</metadata>

--- a/cartridges/app_training/cartridge/scripts/helpers/newsletterEmailHelpers.js
+++ b/cartridges/app_training/cartridge/scripts/helpers/newsletterEmailHelpers.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+* Retrieves the sender email address from the site's custom preferences.
+* 
+* @returns {string} The sender email address configured in the site's preferences.
+*/
+function getSenderEmail() {
+    var Site = require('dw/system/Site');
+
+    var site = Site.getCurrent();
+    var senderEmail = site.getPreferences().custom.senderEmail;
+
+    return senderEmail;
+}
+
+/**
+* Sends a newsletter email notification to a specified recipient, optionally including a coupon code.
+*
+* @param {string} email - The recipient's email address.
+* @param {string} firstName - The recipient's first name.
+* @param {string} lastName - The recipient's last name.
+* @param {string} [couponCode] - An optional coupon code to include in the email.
+*/
+function sendNewsletterEmailNotification(email, firstName, lastName, couponCode) {
+    var emailHelpers = require('*/cartridge/scripts/helpers/emailHelpers');
+    var Resource = require('dw/web/Resource');
+    var senderEmail = getSenderEmail()
+
+    var emailObj = {
+        to: email,
+        subject: Resource.msg('subscribe.email.subject', 'newsletter', null),
+        from: senderEmail,
+    };
+
+    var context = {
+        firstName: firstName,
+        lastName: lastName,
+    }
+    
+    const template = couponCode ? 'newsletterEmailCouponCode' : 'newsletterEmailNoCouponCode';
+    if (couponCode) {
+        context.couponCode = couponCode;
+    }
+
+    emailHelpers.sendEmail(emailObj, template, context);
+}
+
+
+module.exports = {
+    sendNewsletterEmailNotification: sendNewsletterEmailNotification,
+    getSenderEmail: getSenderEmail,
+};
+

--- a/cartridges/app_training/cartridge/templates/default/components/header/pageHeader.isml
+++ b/cartridges/app_training/cartridge/templates/default/components/header/pageHeader.isml
@@ -1,0 +1,67 @@
+<header>
+    <isinclude template="/components/header/skipNav" />
+    <div class="header-banner slide-up d-none">
+        <div class="container">
+            <div class="d-flex justify-content-between">
+                <div></div>
+                <div class="content">
+                    <isslot id="header-banner-m" description="Slot above the site header" context="global" />
+                </div>
+                <div class="close-button">
+                    <button type="button" class="close" aria-label="${Resource.msg('label.header.banner.close', 'common', null)}">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <nav role="navigation">
+        <div class="header container">
+            <div class="row">
+                <div class="col-12">
+                    <div class="navbar-header brand">
+                        <a class="logo-home" href="${URLUtils.url('Home-Show')}" title="${ Resource.msgf('global.homepage.tooltip', 'common', null, Resource.msg('global.storename', 'common', null), Resource.msg('global.home', 'common', null)) }">
+                            <img class="hidden-md-down" src="${URLUtils.staticURL('/images/logo.svg')}" alt="${Resource.msg('global.storename', 'common', null)}" />
+                            <img class="d-lg-none" src="${URLUtils.staticURL('/images/logo-small.svg')}" alt="${Resource.msg('global.storename', 'common', null)}" />
+                        </a>
+                    </div>
+                    <div class="navbar-header">
+                        <div class="pull-left">
+                            <div class="hidden-md-down">
+                                <isinclude url="${URLUtils.url('Account-Header')}" />
+                                <isinclude url="${URLUtils.url('Page-Locale')}" />
+                            </div>
+                            
+                            <a href="${URLUtils.url('NewsletterSubscription-Show')}">
+                                Newsletter
+                            </a>
+                            
+                            <button class="navbar-toggler d-md-none" type="button" aria-controls="sg-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+                                &#9776; <span class="hidden-xs-down">Menu</span>
+                            </button>
+                        </div>
+                        <div class="pull-right">
+                            <div class="search hidden-xs-down">
+                                <isinclude template="components/header/search" />
+                            </div>
+                            <div class="minicart" data-action-url="${URLUtils.url('Cart-MiniCartShow')}">
+                                <isinclude url="${URLUtils.url('Cart-MiniCart')}" />
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="main-menu navbar-toggleable-sm menu-toggleable-left multilevel-dropdown d-none d-md-block" id="sg-navbar-collapse">
+            <div class="container">
+                <div class="row">
+                    <isinclude url="${URLUtils.url('Page-IncludeHeaderMenu')}"/>
+                </div>
+            </div>
+        </div>
+        <div class="search-mobile d-sm-none">
+            <isinclude template="components/header/search" />
+        </div>
+    </nav>
+</header>

--- a/cartridges/app_training/cartridge/templates/default/components/subscriptionForm.isml
+++ b/cartridges/app_training/cartridge/templates/default/components/subscriptionForm.isml
@@ -3,64 +3,54 @@
     method="POST" 
     id="newsletterForm"
 >
-        <div class="form-group required">
-            <label class="form-control-label" for="subscribe-form-email">
-                ${Resource.msg('label.input.email', 'newsletter', null)}
-            </label>
-            <input type="email"
-                   id="subscribe-form-email"
-                   required
-                   aria-required="true"
-                   class="form-control required"
-                   aria-describedby="form-email-error"
-                   name="subscribeEmail"
-                   data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
-                   data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
-                   data-pattern-mismatch="${Resource.msg('error.message.parse.email.profile.form','newsletter',null)}"
-                   value="${pdict.email}"
-            >
-            <div class="invalid-feedback" id="form-email-error"></div>
-        </div>
-
-        <div class="form-group required">
-            <label class="form-control-label" for="subscription-form-firstname">
-                ${Resource.msg('label.input.firstname', 'newsletter', null)}
-            </label>
-            <input type="text" 
-                   id="subscription-form-firstname" 
-                   required 
-                   aria-required="true" 
-                   class="form-control required" 
-                   aria-describedby="form-fname-error" 
-                   name="subscribeFormFirstname"
-                   data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
-                   data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
-                   value="${pdict.firstName}"
-            >
-            <div class="invalid-feedback" id="form-fname-error"></div>
-        </div>
-
-        <div class="form-group required">
-            <label class="form-control-label" for="subscribe-form-lastname">
-                ${Resource.msg('label.input.lastname', 'newsletter', null)}
-            </label>
-            <input type="text"
-                   id="subscribe-form-lastname"
-                   required
-                   aria-required="true"
-                   class="form-control required"
-                   aria-describedby="form-lname-error"
-                   name="subscribeLastname"
-                   data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
-                   data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
-                   value="${pdict.lastName}"
-            >
-            <div class="invalid-feedback" id="form-lname-error"></div>
-        </div>
-
-        <button type="submit" class="btn btn-block btn-primary">${Resource.msg('button.save', 'newsletter', null)}</button>
+    <div class="form-group <isif condition="${!!pdict.profileForm.email.mandatory === true}">required</isif>">
+        <label class="form-control-label" for="subscribe-form-email">
+            ${Resource.msg('label.input.email', 'newsletter', null)}
+        </label>
+        <input type="email"
+               id="subscribe-form-email"
+               aria-required="true"
+               class="form-control required"
+               aria-describedby="form-email-error"
+               name="subscribeFormEmail"
+               data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
+               data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
+               data-pattern-mismatch="${Resource.msg('error.message.parse.email.profile.form','newsletter',null)}"
+               <isprint value=${pdict.profileForm.email.attributes} encoding="off" />
+        >   
+        <div class="invalid-feedback" id="form-email-error"></div>
+    </div>
+    <div class="form-group <isif condition="${!!pdict.profileForm.firstname.mandatory === true}">required</isif>">
+        <label class="form-control-label" for="subscription-form-firstname">
+            ${Resource.msg('label.input.firstname', 'newsletter', null)}
+        </label>
+        <input type="text" 
+               id="subscription-form-firstname" 
+               aria-required="true" 
+               class="form-control required" 
+               aria-describedby="form-fname-error" 
+               name="subscribeFormFirstname"
+               data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
+               data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
+               <isprint value=${pdict.profileForm.firstname.attributes} encoding="off" />
+        >
+        <div class="invalid-feedback" id="form-fname-error"></div>
+    </div>
+    <div class="form-group <isif condition="${!!pdict.profileForm.lastname.mandatory === true}">required</isif>">
+        <label class="form-control-label" for="subscribe-form-lastname">
+            ${Resource.msg('label.input.lastname', 'newsletter', null)}
+        </label>
+        <input type="text"
+               id="subscribe-form-lastname"
+               aria-required="true"
+               class="form-control required"
+               aria-describedby="form-lname-error"
+               name="subscribeFormLastname"
+               data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
+               data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
+               <isprint value=${pdict.profileForm.lastname.attributes} encoding="off" />v
+        >
+        <div class="invalid-feedback" id="form-lname-error"></div>
+    </div>
+    <button type="submit" class="btn btn-block btn-primary">${Resource.msg('button.save', 'newsletter', null)}</button>
 </form>
-
-<iscomment> value="${pdict.form.email.value}" </iscomment>
-<iscomment> value="${pdict.firstName}" </iscomment>
-<iscomment> value="${pdict.form.lastname.value}" </iscomment>

--- a/cartridges/app_training/cartridge/templates/default/components/subscriptionForm.isml
+++ b/cartridges/app_training/cartridge/templates/default/components/subscriptionForm.isml
@@ -1,0 +1,66 @@
+<form 
+    action="${pdict.subscribeNewsletterUrl}" 
+    method="POST" 
+    id="newsletterForm"
+>
+        <div class="form-group required">
+            <label class="form-control-label" for="subscribe-form-email">
+                ${Resource.msg('label.input.email', 'newsletter', null)}
+            </label>
+            <input type="email"
+                   id="subscribe-form-email"
+                   required
+                   aria-required="true"
+                   class="form-control required"
+                   aria-describedby="form-email-error"
+                   name="subscribeEmail"
+                   data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
+                   data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
+                   data-pattern-mismatch="${Resource.msg('error.message.parse.email.profile.form','newsletter',null)}"
+                   value="${pdict.email}"
+            >
+            <div class="invalid-feedback" id="form-email-error"></div>
+        </div>
+
+        <div class="form-group required">
+            <label class="form-control-label" for="subscription-form-firstname">
+                ${Resource.msg('label.input.firstname', 'newsletter', null)}
+            </label>
+            <input type="text" 
+                   id="subscription-form-firstname" 
+                   required 
+                   aria-required="true" 
+                   class="form-control required" 
+                   aria-describedby="form-fname-error" 
+                   name="subscribeFormFirstname"
+                   data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
+                   data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
+                   value="${pdict.firstName}"
+            >
+            <div class="invalid-feedback" id="form-fname-error"></div>
+        </div>
+
+        <div class="form-group required">
+            <label class="form-control-label" for="subscribe-form-lastname">
+                ${Resource.msg('label.input.lastname', 'newsletter', null)}
+            </label>
+            <input type="text"
+                   id="subscribe-form-lastname"
+                   required
+                   aria-required="true"
+                   class="form-control required"
+                   aria-describedby="form-lname-error"
+                   name="subscribeLastname"
+                   data-missing-error="${Resource.msg('error.message.required','newsletter',null)}"
+                   data-range-error="${Resource.msg('error.message.50orless','newsletter',null)}"
+                   value="${pdict.lastName}"
+            >
+            <div class="invalid-feedback" id="form-lname-error"></div>
+        </div>
+
+        <button type="submit" class="btn btn-block btn-primary">${Resource.msg('button.save', 'newsletter', null)}</button>
+</form>
+
+<iscomment> value="${pdict.form.email.value}" </iscomment>
+<iscomment> value="${pdict.firstName}" </iscomment>
+<iscomment> value="${pdict.form.lastname.value}" </iscomment>

--- a/cartridges/app_training/cartridge/templates/default/newsletterEmailCouponCode.isml
+++ b/cartridges/app_training/cartridge/templates/default/newsletterEmailCouponCode.isml
@@ -1,0 +1,9 @@
+<body>
+    <p>${Resource.msg('label.newsletter.dear', 'newsletter', null)} ${pdict.firstName} ${pdict.lastName},</p>
+    <br>
+    <p>${Resource.msg('label.newsletter.thanks', 'newsletter', null)}</p>
+    <br>
+    <p>${Resource.msg('subscribe.email.message', 'newsletter', null)}</p>
+    <br>
+    <p>${Resource.msg('subscribe.email.message.coupon.code', 'newsletter', null)} ${pdict.couponCode}</p>
+</body>

--- a/cartridges/app_training/cartridge/templates/default/newsletterEmailNoCouponCode.isml
+++ b/cartridges/app_training/cartridge/templates/default/newsletterEmailNoCouponCode.isml
@@ -1,0 +1,9 @@
+<body>
+    <p>${Resource.msg('label.newsletter.dear', 'newsletter', null)} ${pdict.firstName} ${pdict.lastName},</p>
+    <br>
+    <p>${Resource.msg('label.newsletter.thanks', 'newsletter', null)}</p>
+    <br>
+    <p>${Resource.msg('subscribe.email.message', 'newsletter', null)}</p>
+    <br>
+    <p>${Resource.msg('label.newsletter.no.coupon.codes.left', 'newsletter', null)}</p>
+</body>

--- a/cartridges/app_training/cartridge/templates/default/newsletterSubscription.isml
+++ b/cartridges/app_training/cartridge/templates/default/newsletterSubscription.isml
@@ -1,0 +1,29 @@
+<isdecorate template="common/layout/page">
+    <isscript>
+        var assets = require('*/cartridge/scripts/assets.js');
+        assets.addCss('/css/login.css');
+        assets.addJs('/js/login.js');
+    </isscript>
+
+    <div class="hero slant-down login-banner">
+        <h1 class="page-title">${Resource.msg('header.hero.image.newsletter', 'newsletter', null)}</h1>
+    </div>
+    <div class="container login-page">
+        <div class="row justify-content-center equal-height">
+            <div class="col-sm-8 col-md-6">
+                <div class="card">
+                    <div class="card-body">
+                        <!-- Check if there is an error message -->
+                        <isif condition="${pdict.error}">
+                            <div class="alert alert-danger" role="alert">
+                                ${pdict.error}
+                            </div>
+                        </isif>
+                    
+                        <isinclude template="components/subscriptionForm" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</isdecorate>

--- a/cartridges/app_training/cartridge/templates/resources/newsletter.properties
+++ b/cartridges/app_training/cartridge/templates/resources/newsletter.properties
@@ -1,0 +1,32 @@
+# labels
+label.input.firstname=First Name
+label.input.lastname=Last Name
+label.input.email=E-mail
+label.newsletter.subscription=Newsletter Subscription
+label.newsletter.dear=Dear
+label.newsletter.thanks=Thank you for signing up to receive our newsletter!
+label.newsletter.no.coupon.codes.left=I am sorry, there are no coupon codes left.
+header.hero.image.newsletter=Newsletter
+subscribe.email.message.coupon.code=Your Coupon Code is 
+subscribe.email.message=Starting today you will receive our newsletter.
+subscribe.email.subject=Newsletter Sign Up
+
+
+# placeholders
+placeholder.email=E-mail
+
+
+# buttons
+button.save=Save
+
+# error messages
+error.message.required=This field is required.
+error.message.50orless=Please enter 50 characters or less.
+error.message.parse.email=Please enter a valid email address.
+error.message.invalid.email=Invalid email format.
+error.message.parse.email.profile.form=Please enter a valid E-Mail address
+error.message.already.subscribed=This email address is already subscribed.
+subscribe.email.error=There was an error with your subscription.
+
+subscribe.email.success=You have successfully subscribed to the newsletter and receive a coupon for $20 off for an order.
+


### PR DESCRIPTION
**Summary:**
**1.** I added a link to testing purposes in pageHeader.isml for easy access to route 'NewsletterSubsription-Show', which is the form for submitting requests.
![image](https://github.com/user-attachments/assets/cf5d2066-85f4-4336-ad57-2d3f7167ff52)

**2.** There are 2 routes in NewsletterSubcription controller - 1st 'Show' for displaying the form and 2nd 'Subscribe' for submitting the form. After submitting the form the user is redirected to Home page.
I tried to use the form management from registration process.

**Notes**
- authorized and unauthorized users can subscribe
- metadata files are in app_training/cartridge/metadata

**Form:**
![image](https://github.com/user-attachments/assets/aa00063c-fe8d-4a25-bf55-00d8818d3f9a)

**Successful subscription with coupon code:**
![image](https://github.com/user-attachments/assets/c4b6aa6e-3d36-4dd4-bbc9-ba924f8eb822)

**Custom Object NewsletterSubscription:**
![image](https://github.com/user-attachments/assets/e65bab82-4a7d-4801-8bc8-05f4879fdb12)

**Site Preference senderEmail:**
![image](https://github.com/user-attachments/assets/b3cf96e0-c1db-42be-8af8-16af1cca0d1c)
![image](https://github.com/user-attachments/assets/927d99ff-ebbe-4276-83b9-a2dd9e8822d2)
![image](https://github.com/user-attachments/assets/bd3361d6-b713-4c7a-8d08-508094bdc5d8)

**Coupon:**
![image](https://github.com/user-attachments/assets/d73a9a79-93ee-4c4c-afee-c423778a97a0)


**3. Edge cases:**
- No coupons left
![image](https://github.com/user-attachments/assets/d72b1054-6f75-4950-9bc9-ec93774e04e5)

- User is already subscribed
![image](https://github.com/user-attachments/assets/8672e0ed-d7c9-4c78-ab59-687fdfc90997)

